### PR TITLE
Add Drawtoon (AI manga/manhwa) to 国外 platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ AI这样把NB写在脸上，它在玩一种很新的艺术
 |novelai-colab 版本|免费 |https://github.com/acheong08/Diffusion-ColabUI |
 |novelai-colab 版本2|免费 |https://github.com/JingShing/novelai-colab-ver |
 |Maze.Guru|免费 |https://maze.guru |
+|Drawtoon (AI漫画/manhwa)|有免费/付费 |https://drawtoon.app |
 
 
 


### PR DESCRIPTION
在「📪 国外」平台表格中新增 **Drawtoon** —— 一个 AI 漫画/manhwa 创作工具，输入故事提示即可生成带有连贯角色、分镜和对白的完整漫画页面。

Adds **Drawtoon** to the international platforms table — an AI manga & manhwa studio that turns a story prompt into full comic pages with consistent characters, panels, and dialogue. https://drawtoon.app

Thanks! / 谢谢